### PR TITLE
Use port 3001 and make setup idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+- Run `npm test` in `youtube-transcript-service` after making changes.
+- Follow standard JavaScript style conventions.

--- a/youtube-transcript-service/README.md
+++ b/youtube-transcript-service/README.md
@@ -12,14 +12,14 @@ cd AI-Lab/youtube-transcript-service
 ./setup.sh
 ```
 
-The script installs Node.js (if missing), installs dependencies and creates a `transcript` systemd service listening on port `3000`.
+The script installs Node.js (if missing), installs or updates dependencies, recreates the `transcript` systemd service, and restarts it on port `3001`.
 
 ## API
 
 Send a POST request with JSON body `{ "url": "https://youtu.be/..." }` to receive the transcript as plain text:
 
 ```bash
-curl -X POST http://localhost:3000/transcript \
+curl -X POST http://localhost:3001/transcript \
   -H 'Content-Type: application/json' \
   -d '{"url":"https://youtu.be/dQw4w9WgXcQ"}'
 ```

--- a/youtube-transcript-service/server.js
+++ b/youtube-transcript-service/server.js
@@ -6,18 +6,21 @@ app.use(express.json());
 
 app.post('/transcript', async (req, res) => {
   const { url } = req.body;
+  console.log('Transcript request:', url);
   if (!url) {
     return res.status(400).json({ error: 'url required' });
   }
   try {
     const items = await YoutubeTranscript.fetchTranscript(url);
     const text = items.map(i => i.text).join(' ').replace(/\s+/g, ' ').trim();
+    console.log(`Transcript fetched (${items.length} segments)`);
     res.type('text/plain').send(text);
   } catch (e) {
+    console.error('Transcript fetch error:', e.message);
     res.status(500).json({ error: e.message });
   }
 });
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 app.listen(port, () => console.log(`Listening on port ${port}`));
 

--- a/youtube-transcript-service/setup.sh
+++ b/youtube-transcript-service/setup.sh
@@ -10,11 +10,11 @@ if ! command -v node >/dev/null 2>&1; then
   sudo apt-get install -y nodejs
 fi
 
-# Install dependencies
 cd "$APP_DIR"
+# Install or update dependencies
 npm install --production
 
-# Create systemd service
+# Create or update systemd service
 SERVICE_FILE="/etc/systemd/system/transcript.service"
 sudo tee "$SERVICE_FILE" > /dev/null <<SERVICE
 [Unit]
@@ -30,9 +30,9 @@ Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 SERVICE
-
 sudo systemctl daemon-reload
-sudo systemctl enable --now transcript.service
+sudo systemctl enable transcript.service
+sudo systemctl restart transcript.service
 
-echo "Service started. Listening on port 3000"
+echo "Service started. Listening on port 3001"
 


### PR DESCRIPTION
## Summary
- default YouTube transcript service to port 3001
- emit basic stdout logs for transcript requests
- make setup script idempotent, reinstall dependencies, and recreate service to update existing installs
- add root-level AGENTS.md with minimal repository guidance

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68993a3598ec8332b55808a91fc7e238