### PR TITLE
Handle youtu.be URLs with extra params

### DIFF
--- a/youtube-transcript-service/package.json
+++ b/youtube-transcript-service/package.json
@@ -4,7 +4,7 @@
   "description": "Small Node.js service that returns YouTube video transcripts",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "NODE_ENV=test node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/youtube-transcript-service/server.js
+++ b/youtube-transcript-service/server.js
@@ -1,8 +1,20 @@
 import express from 'express';
 import { YoutubeTranscript } from 'youtube-transcript';
 
-const app = express();
+export const app = express();
 app.use(express.json());
+
+export function extractVideoId(url) {
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') {
+      return u.pathname.slice(1);
+    }
+    return u.searchParams.get('v') ?? url;
+  } catch {
+    return url;
+  }
+}
 
 app.post('/transcript', async (req, res) => {
   const { url } = req.body;
@@ -11,7 +23,8 @@ app.post('/transcript', async (req, res) => {
     return res.status(400).json({ error: 'url required' });
   }
   try {
-    const items = await YoutubeTranscript.fetchTranscript(url);
+    const videoId = extractVideoId(url);
+    const items = await YoutubeTranscript.fetchTranscript(videoId);
     const text = items.map(i => i.text).join(' ').replace(/\s+/g, ' ').trim();
     console.log(`Transcript fetched (${items.length} segments)`);
     res.type('text/plain').send(text);
@@ -21,6 +34,8 @@ app.post('/transcript', async (req, res) => {
   }
 });
 
-const port = process.env.PORT || 3001;
-app.listen(port, () => console.log(`Listening on port ${port}`));
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3001;
+  app.listen(port, () => console.log(`Listening on port ${port}`));
+}
 

--- a/youtube-transcript-service/server.test.js
+++ b/youtube-transcript-service/server.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import { YoutubeTranscript } from 'youtube-transcript';
+import { app } from './server.js';
+
+test('handles youtu.be URLs with extra params', async (t) => {
+  const calls = [];
+  mock.method(YoutubeTranscript, 'fetchTranscript', async (id) => {
+    calls.push(id);
+    return [{ text: 'hi' }];
+  });
+
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/transcript`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: 'https://youtu.be/abc123?si=something' })
+  });
+
+  assert.equal(res.status, 200);
+  const text = await res.text();
+  assert.equal(text, 'hi');
+  assert.equal(calls[0], 'abc123');
+});


### PR DESCRIPTION
## Summary
- Normalize YouTube URLs by extracting video ID, ensuring short links with query params are handled
- Export Express app and skip listening in test environment
- Add test for youtu.be URL with extra params and enable Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993e3da7088332baafeaa079141478