### PR TITLE
feat: add polite throttling and caching

### DIFF
--- a/youtube-transcript-service/extractVideoID.test.js
+++ b/youtube-transcript-service/extractVideoID.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractVideoID } from './server.js';
+
+const cases = [
+  ['https://youtu.be/abc123', 'abc123'],
+  ['https://www.youtube.com/watch?v=abc123', 'abc123'],
+  ['https://youtube.com/watch?v=abc123', 'abc123'],
+  ['https://music.youtube.com/watch?v=abc123', 'abc123'],
+  ['https://m.youtube.com/watch?v=abc123', 'abc123']
+];
+
+for (const [url, id] of cases) {
+  test(`extracts id from ${url}`, () => {
+    assert.equal(extractVideoID(url), id);
+  });
+}
+
+test('rejects non youtube urls', () => {
+  assert.throws(() => extractVideoID('https://example.com/watch?v=abc123'));
+});


### PR DESCRIPTION
## Summary
- serialize downloads with a paced FIFO queue and exponential backoff
- harden YouTube URL parsing and cache transcripts on disk
- invoke yt-dlp with conservative settings to avoid throttling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a202f818608332a5608c4eaa55d584