### PR TITLE
Add video metadata to transcripts

### DIFF
--- a/youtube-transcript-service/README.md
+++ b/youtube-transcript-service/README.md
@@ -1,6 +1,6 @@
 # YouTube Transcript Service
 
-Small Node.js service that transcribes audio using [Whisper](https://github.com/openai/whisper). It can download audio from a YouTube URL or transcribe an uploaded audio file.
+Small Node.js service that transcribes audio using [Whisper](https://github.com/openai/whisper). It can download audio from a YouTube URL or transcribe an uploaded audio file. Transcriptions include basic video metadata at the top.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary
- add metadata retrieval via yt-dlp and prepend info to returned transcripts
- document that transcripts now include basic video metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20afb79288332b838ecfd244a8b37