### PR TITLE
Add async job polling API

### DIFF
--- a/youtube-transcript-service/README.md
+++ b/youtube-transcript-service/README.md
@@ -17,6 +17,8 @@ The server searches for the Whisper CLI in your `PATH` or at `~/.local/bin/whisp
 
 ## API
 
+### `/transcript`
+
 Send a POST request with JSON body containing a YouTube URL to receive the transcription as plain text:
 
 ```bash
@@ -31,6 +33,36 @@ To transcribe a local audio file, upload it via `PUT` using multipart form data:
 curl -X PUT http://localhost:3001/transcript \
   -F file=@/path/to/audio.mp3
 ```
+
+### `/jobs`
+
+For long-running transcriptions or Shortcuts clients, create a job and poll until the transcript is ready.
+
+1. **Create a job**
+
+   ```bash
+   curl -X POST http://localhost:3001/jobs \
+     -H 'Content-Type: application/json' \
+     -d '{"url":"https://youtu.be/dQw4w9WgXcQ"}'
+   ```
+
+   Returns `202 Accepted` with `{ id, status }`.
+
+2. **Poll status**
+
+   ```bash
+   curl http://localhost:3001/jobs/<job-id>/status
+   ```
+
+   Responds with `{ id, status, error? }` until `status` becomes `done`.
+
+3. **Fetch result**
+
+   ```bash
+   curl http://localhost:3001/jobs/<job-id>/result
+   ```
+
+   When `status` is `done`, this returns the transcript as plain text. Completed results are cached by video so repeat requests finish immediately.
 
 To run the optional integration test that exercises Whisper locally, set `RUN_WHISPER_TEST=1` before executing `npm test`.
 

--- a/youtube-transcript-service/server.test.js
+++ b/youtube-transcript-service/server.test.js
@@ -1,6 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { app, normalizeYoutubeUrl } from './server.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+process.env.CACHE_DIR = fs.mkdtempSync(path.join(tmpdir(), 'cache-'));
+process.env.JOB_SKIP = '1';
+const { app, normalizeYoutubeUrl } = await import('./server.js');
 
 test('requires url', async (t) => {
   const server = app.listen(0);
@@ -50,4 +56,72 @@ test('normalizes shared links', () => {
   const url = 'https://youtu.be/ZOYaz3SIjHw?si=0grwE-vtOlULzYHN';
   const normalized = normalizeYoutubeUrl(url);
   assert.equal(normalized, 'https://www.youtube.com/watch?v=ZOYaz3SIjHw');
+});
+
+test('job creation requires url', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/jobs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({})
+  });
+  assert.equal(res.status, 400);
+});
+
+test('job creation rejects invalid url', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/jobs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: 'https://example.com/video' })
+  });
+  assert.equal(res.status, 400);
+});
+
+test('job status and result 404 for unknown id', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const statusRes = await fetch(`http://localhost:${port}/jobs/unknown/status`);
+  assert.equal(statusRes.status, 404);
+  const resultRes = await fetch(`http://localhost:${port}/jobs/unknown/result`);
+  assert.equal(resultRes.status, 404);
+});
+
+test('job creation returns id', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/jobs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: 'https://www.youtube.com/watch?v=ZOYaz3SIjHw' })
+  });
+  assert.equal(res.status, 202);
+  const data = await res.json();
+  assert.ok(data.id);
+  assert.equal(data.status, 'queued');
+});
+
+test('job returns done immediately when cached', async (t) => {
+  const videoId = 'DUMMYID12345';
+  const cachedText = 'cached transcript';
+  fs.writeFileSync(path.join(process.env.CACHE_DIR, `${videoId}.txt`), cachedText);
+  const server = app.listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/jobs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url: `https://www.youtube.com/watch?v=${videoId}` })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.status, 'done');
+  const result = await fetch(`http://localhost:${port}/jobs/${data.id}/result`);
+  assert.equal(await result.text(), cachedText);
 });


### PR DESCRIPTION
## Summary
- add in-memory job queue with worker and TTL cleanup
- expose `/jobs` API for asynchronous transcript requests and polling
- test job endpoints and ensure server test environment skips heavy work
- cache transcripts for both `/transcript` and `/jobs`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2121df39883329591369ad20a1013