### PR TITLE
Limit Whisper concurrency and add timeouts with cache sweeps

### DIFF
--- a/youtube-transcript-service/README.md
+++ b/youtube-transcript-service/README.md
@@ -73,5 +73,5 @@ To run the optional integration test that exercises Whisper locally, set `RUN_WH
 | `MAX_DOWNLOAD_MS` | Timeout for YouTube downloads in milliseconds | `300000` |
 | `MAX_TRANSCRIBE_MS` | Timeout for Whisper transcription in milliseconds | `900000` |
 | `WHISPER_CONCURRENCY` | Maximum concurrent Whisper processes | `1` |
-| `CACHE_MAX_BYTES` | Maximum total size of cached transcripts; `0` disables the limit | `0` |
+| `CACHE_MAX_BYTES` | Maximum total size of cached transcripts; set `0` to disable the limit | `536870912` |
 

--- a/youtube-transcript-service/README.md
+++ b/youtube-transcript-service/README.md
@@ -54,7 +54,7 @@ For long-running transcriptions or Shortcuts clients, create a job and poll unti
    curl http://localhost:3001/jobs/<job-id>/status
    ```
 
-   Responds with `{ id, status, error? }` until `status` becomes `done`.
+   Responds with `{ id, status, error? }` as the job moves from `downloading` → `transcribing` → `ready`.
 
 3. **Fetch result**
 
@@ -62,7 +62,16 @@ For long-running transcriptions or Shortcuts clients, create a job and poll unti
    curl http://localhost:3001/jobs/<job-id>/result
    ```
 
-   When `status` is `done`, this returns the transcript as plain text. Completed results are cached by video so repeat requests finish immediately.
+When `status` is `ready`, this returns the transcript as plain text. Completed results are cached by video so repeat requests finish immediately.
 
 To run the optional integration test that exercises Whisper locally, set `RUN_WHISPER_TEST=1` before executing `npm test`.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MAX_DOWNLOAD_MS` | Timeout for YouTube downloads in milliseconds | `300000` |
+| `MAX_TRANSCRIBE_MS` | Timeout for Whisper transcription in milliseconds | `900000` |
+| `WHISPER_CONCURRENCY` | Maximum concurrent Whisper processes | `1` |
+| `CACHE_MAX_BYTES` | Maximum total size of cached transcripts; `0` disables the limit | `0` |
 

--- a/youtube-transcript-service/server.js
+++ b/youtube-transcript-service/server.js
@@ -21,7 +21,7 @@ const MAX_DOWNLOAD_MS = parseInt(process.env.MAX_DOWNLOAD_MS || '300000', 10);
 const MAX_TRANSCRIBE_MS = parseInt(process.env.MAX_TRANSCRIBE_MS || '900000', 10);
 const WHISPER_CONCURRENCY = parseInt(process.env.WHISPER_CONCURRENCY || '1', 10);
 const CACHE_SWEEP_MS = parseInt(process.env.CACHE_SWEEP_MS || '3600000', 10);
-const CACHE_MAX_BYTES = parseInt(process.env.CACHE_MAX_BYTES || '0', 10);
+const CACHE_MAX_BYTES = parseInt(process.env.CACHE_MAX_BYTES || '536870912', 10);
 
 fs.mkdirSync(CACHE_DIR, { recursive: true });
 

--- a/youtube-transcript-service/server.test.js
+++ b/youtube-transcript-service/server.test.js
@@ -107,7 +107,7 @@ test('job creation returns id', async (t) => {
   assert.equal(data.status, 'queued');
 });
 
-test('job returns done immediately when cached', async (t) => {
+test('job returns ready immediately when cached', async (t) => {
   const videoId = 'DUMMYID12345';
   const cachedText = 'cached transcript';
   fs.writeFileSync(path.join(process.env.CACHE_DIR, `${videoId}.txt`), cachedText);
@@ -121,7 +121,7 @@ test('job returns done immediately when cached', async (t) => {
   });
   assert.equal(res.status, 200);
   const data = await res.json();
-  assert.equal(data.status, 'done');
+  assert.equal(data.status, 'ready');
   const result = await fetch(`http://localhost:${port}/jobs/${data.id}/result`);
   assert.equal(await result.text(), cachedText);
 });


### PR DESCRIPTION
## Summary
- throttle Whisper via a concurrency-limited queue and expose `WHISPER_CONCURRENCY`
- abort long-running yt-dlp downloads and Whisper transcribes with `MAX_DOWNLOAD_MS` and `MAX_TRANSCRIBE_MS`
- periodically sweep transcript cache with optional `CACHE_MAX_BYTES`
- surface job progress states `downloading` and `transcribing` before `ready`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2268d5af483329311e2d92ecdd1cb